### PR TITLE
lists: Fix a typo in the description of list_swap().

### DIFF
--- a/include/lists.tex
+++ b/include/lists.tex
@@ -17,7 +17,7 @@
 \texttt{list\_del\_init(e)} & $\hookrightarrow$ reinitialize \texttt{e} \\
 \texttt{list\_replace(old, new)} & Replace \texttt{old} by \texttt{new} \\
 \texttt{list\_replace\_init(old, new)} & $\hookrightarrow$ reinitialize \texttt{old} \\
-\texttt{list\_swap(e1, e2)} & Swap \texttt{e1} and \texttt{t2} \\
+\texttt{list\_swap(e1, e2)} & Swap \texttt{e1} and \texttt{e2} \\
 \texttt{list\_move(e, head)} & Remove \texttt{e}; add to the start of \texttt{head} \\
 \texttt{list\_move\_tail(e, head)} & Remove \texttt{e}; add to the end of \texttt{head} \\
 %\texttt{list\_bulk\_move\_tail(head, first, last)} & Move elements from \texttt{first} and \texttt{last} (both inclusive) to 


### PR DESCRIPTION
s/t2/e2/

Signed-off-by: Kuniyuki Iwashima <kuni1840@gmail.com>